### PR TITLE
Addition of setup.py for uclasm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+from setuptools import setup
+
+setup(
+    name='uclasm',
+    version='1.0',
+    description='Module for Subgraph Isomorphism',
+    author='Jacob Moorman, Thomas Tu, Xie He, Qinyi Chen',
+    packages=['uclasm', 'uclasm.utils', 'uclasm.filters', 'uclasm.counting'],
+    install_requires=['numpy', 'scipy', 'matplotlib', 'pandas', 'networkx', 'ipython']
+)


### PR DESCRIPTION
This adds a setup.py to uclasm. This makes it so that after running _python setup.py install_ (or _python setup.py develop_), that the uclasm package may be imported from anywhere. 